### PR TITLE
fix: Replace deprecated kIOMasterPortDefault

### DIFF
--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -1,0 +1,25 @@
+name: Go
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17
+
+    - name: Build
+      run: go build -v ./...
+
+    - name: Test
+      run: go test -v ./...


### PR DESCRIPTION
Replace kIOMasterPortDefault with kIOMainPortDefault.

Pulled in an update from https://github.com/Zondax/hid/blob/6f30845d880fbf88a7b5ee8f446ac5e8c10c760b/hidapi/mac/hid.c which belongs to https://github.com/Zondax/hid/pull/3 instead of trying to write something myself.

Fixes https://github.com/Zondax/hid/issues/4